### PR TITLE
Add receive function to contracts to enable ETH reception

### DIFF
--- a/apps/hardhat/contracts/carbon.credit.sol
+++ b/apps/hardhat/contracts/carbon.credit.sol
@@ -25,6 +25,11 @@ contract CarbonCredit is ERC20, ERC20Burnable, ERC20Pausable, Ownable {
         _burn(from, amount);
     }
 
+    // Function to receive ETH when sent to this contract
+    receive() external payable {
+        // Contract can now receive and hold ETH
+    }
+
     // The following functions are overrides required by Solidity.
     function _update(address from, address to, uint256 value)
         internal

--- a/apps/hardhat/contracts/carbon.offset.mngr.sol
+++ b/apps/hardhat/contracts/carbon.offset.mngr.sol
@@ -18,8 +18,8 @@ contract CarbonOffsetManager is Ownable {
     event OffsetToProject(uint256 amount, address sourceCompany, uint256 nftId);
 
     constructor(address _carbonCredit, address _offsetNFT, address _centralWallet, address initialOwner) Ownable(initialOwner) {
-        carbonCredit = CarbonCredit(_carbonCredit);
-        offsetNFT = OffsetNFT(_offsetNFT);
+        carbonCredit = CarbonCredit(payable(_carbonCredit));
+        offsetNFT = OffsetNFT(payable(_offsetNFT));
         centralWallet = _centralWallet;
     }
 
@@ -81,6 +81,11 @@ contract CarbonOffsetManager is Ownable {
 
     function setCentralWallet(address newCentralWallet) public onlyOwner {
         centralWallet = newCentralWallet;
+    }
+
+    // Function to receive ETH when sent to this contract
+    receive() external payable {
+        // Contract can now receive and hold ETH
     }
 
     // Debug function

--- a/apps/hardhat/contracts/offset.nft.sol
+++ b/apps/hardhat/contracts/offset.nft.sol
@@ -18,6 +18,11 @@ contract OffsetNFT is ERC721, ERC721URIStorage, Ownable {
         return newTokenId;
     }
 
+    // Function to receive ETH when sent to this contract
+    receive() external payable {
+        // Contract can now receive and hold ETH
+    }
+
     // The following functions are overrides required by Solidity.
     function tokenURI(uint256 tokenId) public view override(ERC721, ERC721URIStorage) returns (string memory) {
         return super.tokenURI(tokenId);


### PR DESCRIPTION
This pull request adds the ability for all three core smart contracts (`CarbonCredit`, `CarbonOffsetManager`, and `OffsetNFT`) to receive and hold ETH directly. Additionally, it updates the constructors in `CarbonOffsetManager` to use payable addresses for contract references, ensuring compatibility with ETH transfers.

**Smart contract ETH handling:**

* Added a `receive()` external payable function to `CarbonCredit`, allowing the contract to accept and hold ETH.
* Added a `receive()` external payable function to `CarbonOffsetManager`, enabling it to accept and hold ETH.
* Added a `receive()` external payable function to `OffsetNFT`, so it can receive and hold ETH.

**Constructor updates for contract references:**

* Updated the `CarbonOffsetManager` constructor to cast `carbonCredit` and `offsetNFT` addresses as payable, supporting ETH transfers between contracts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Contracts can now receive ETH directly, enabling simpler funding and seamless wallet/dapp interactions when sending ETH to contract addresses.
  - Carbon credits, offsets, and NFT contracts support holding ETH, improving compatibility with payment flows and future on-chain features.
  - Enhanced ETH handling in the offset manager streamlines deposits/top-ups without invoking specific methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->